### PR TITLE
修正無行動猜拳的賓果線，並調整自動計算後的賓果顯示順序

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -210,7 +210,7 @@
 }
 .demo-block img {
     width: 100%;
-    height: auto;
+    height: 100%;
 }
 .material-icons {
     font-size: 1.2em;


### PR DESCRIPTION
我後來發現無行動的猜拳賓果在特定情況下還是有bug會被畫線，已修掉

另外調整自動排列的計算邏輯：
增加把總猜拳數優先納入排序條件的 key
這樣當在賓果總數相同的情況下，如果遇到某圖形可以同時排列出有『多種屬性』或『多種猜拳』的結果時，猜拳賓果數較多者固定會優先顯示。